### PR TITLE
fixed zbx_docker_perm() to get container naming functional on CentOSs…

### DIFF
--- a/src/modules/zabbix_module_docker/zabbix_module_docker.c
+++ b/src/modules/zabbix_module_docker/zabbix_module_docker.c
@@ -1004,7 +1004,7 @@ int     zbx_docker_perm()
                gr = getgrgid(groups[j]);
                if (gr != NULL)
                {
-                   if (strcmp(gr->gr_name, "docker") == 0)
+                   if((strcmp(gr->gr_name, "docker") == 0) || (strcmp(gr->gr_name, "dockerroot") == 0))
                    {
                        zabbix_log(LOG_LEVEL_DEBUG, "zabbix agent user has docker perm");
                        return 1;


### PR DESCRIPTION
… dockerroot group

In reference to Issue #17 here's a quick fix for CentOS with dockerroot group